### PR TITLE
APP-11 - Configurar testes unitários

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ node_modules
 coverage
 webpack.*.js
 server
+**__snapshots__

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ jspm_packages
 .env
 /yarn-debug.log*
 /yarn-error.log*
+
+# Component result tests
+**__snapshots__

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ addons:
 cache:
   directories:
     - node_modules
+after_script:
+  - codecov

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > Software for coderockr challenge
 
 [![Build Status](https://travis-ci.org/renatobenks/CodeRockrApplication.svg?branch=master)](https://travis-ci.org/renatobenks/CodeRockrApplication)
+[![codecov](https://codecov.io/gh/renatobenks/CodeRockrApplication/branch/master/graph/badge.svg)](https://codecov.io/gh/renatobenks/CodeRockrApplication)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/200adf02253c453abda33f348e73f5d4)](https://www.codacy.com/app/renato-benkendorf/CodeRockrApplication?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=renatobenks/CodeRockrApplication&amp;utm_campaign=Badge_Grade)
 
 Docker *(recommended)*

--- a/package.json
+++ b/package.json
@@ -3,8 +3,13 @@
   "version": "0.1.0",
   "private": false,
   "devDependencies": {
+    "babel-jest": "^19.0.0",
+    "codecov": "^2.1.0",
     "eslint": "^3.19.0",
-    "eslint-plugin-react": "^6.10.3"
+    "eslint-plugin-react": "^6.10.3",
+    "jest": "^19.0.2",
+    "react-test-renderer": "^15.5.4",
+    "regenerator-runtime": "^0.10.3"
   },
   "dependencies": {
     "assets-webpack-plugin": "^3.5.1",
@@ -39,10 +44,28 @@
     "webpack-hot-middleware": "^2.18.0"
   },
   "scripts": {
-    "start": "cross-env NODE_ENV=development node ./index.js",
+    "start": "./node_modules/.bin/cross-env NODE_ENV=development node ./index.js",
     "production": "./node_modules/.bin/cross-env NODE_ENV=production node ./index.js",
     "build": "./node_modules/.bin/webpack -p --config ./webpack.config.prod.js",
-    "test": "echo 'No test runner yet!'",
+    "test": "./node_modules/.bin/jest --colors",
+    "test:report": "npm test && ./node_modules/.bin/codecov",
+    "test:watch": "npm test -- --watch",
     "clean": "rm -rf build/ assets.json"
+  },
+  "jest": {
+    "verbose": true,
+    "transform": {
+      ".*": "babel-jest"
+    },
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "node",
+      "jsx"
+    ],
+    "coverageDirectory": "./coverage/",
+    "collectCoverage": true,
+    "testEnvironment": "node",
+    "testRegex": "\\.test\\.jsx?$"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,8 @@
 import React, { Component } from 'react';
-import logo from '../public/images/logo.svg';
 
 class App extends Component {
     render () {
-        const { title } = this.props;
+        const { title, logo } = this.props;
         return (
             <div className='App'>
                 <div className='App-header'>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,12 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactRender from 'react-test-renderer';
+
 import App from './App';
 
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
+const component = ReactRender.create(
+    <App logo="logo.svg" title="My title app"/>
+);
+
+test('renders without crashing', () => {
+    expect(component.toJSON()).toMatchSnapshot();
 });

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,13 @@ import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { AppContainer } from 'react-hot-loader';
+import logo from '../public/images/logo.svg';
 import App from './App';
 
 const render = (Container) => {
     ReactDOM.render(
         <AppContainer>
-            <Container {...window.INITIAL_STATE} />
+            <Container logo={logo} {...window.INITIAL_STATE} />
         </AppContainer>,
         document.getElementById('root')
     );


### PR DESCRIPTION
Configurar testes unitários #11
---

Backlog:

- [x] ~~Jest~~ - Configurar ambiente para executar o testes usando o node.js para ganho de performance nos testes.
- [x] ~~Jest with Babel~~ - Integrar o babel com o jest para desenvolver os testes usando os recursos de ES6. Usando as libs `babel-jest` & `regenerator-runtime`
- [x] ~~Code Coverage~~ - Integrar ferramenta de para integrar ao app (decidir qual melhor ferramenta à usar: `instanbul`, `codecov`, etc).
- [x] ~~Badge~~ - Implementar o badge do coverage do app
---

Com a utilização do Jest como framework de teste escolhido para o uso no app, foi refatorado o `App.test.js`, gerado pelo `creat-react-app`, para que testasse o componente React `App` da aplicação, com o uso das features do Jest e o teste passe com 100& de cobertura, cobrindo a responsabilidade do componente.

Foi usado o code coverage do Jest, um recurso nativo integrado ao framework, para gerar o report para enviar para o codecov, integrado a aplicação, para fazer o report da cobertura de código da aplicação.

*A intenção é deixar a aplicação cobrindo no minimo, 95% do código da aplicação.*